### PR TITLE
Added simple static website, with a simple unit test

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,3 +3,9 @@ module "sandpit" {
   cidr_block = "10.0.0.0/16"
   name       = "dms1981"
 }
+
+module "static-website" {
+  source = "./modules/static-website"
+  files  = ["./website/index.html"]
+  name   = "hamsters"
+}

--- a/terraform/modules/static-website/locals.tf
+++ b/terraform/modules/static-website/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  tags = {
+    owner       = "david.sibley@digital.justice.gov.uk"
+    environment = terraform.workspace
+  }
+}

--- a/terraform/modules/static-website/main.tf
+++ b/terraform/modules/static-website/main.tf
@@ -1,0 +1,41 @@
+resource "random_id" "name" {
+  byte_length = 4
+}
+
+resource "azurerm_resource_group" "main" {
+  location = "UK South"
+  name     = format("%s-%s-%s-rg", random_id.name.hex, var.name, terraform.workspace)
+  tags = merge(
+    local.tags,
+    { Name = format("%s-%s-%s-rg", random_id.name.hex, var.name, terraform.workspace) }
+  )
+}
+
+resource "azurerm_storage_account" "main" {
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  location                 = azurerm_resource_group.main.location
+  name                     = replace(format("%s-%s", random_id.name.hex, var.name), "-","")
+  resource_group_name      = azurerm_resource_group.main.name
+
+  static_website {
+    index_document = "index.html"
+  }
+
+  tags = merge(
+    local.tags,
+    { Name = format("%s-%s-%s-storage", random_id.name.hex, var.name, terraform.workspace) }
+  )
+}
+
+resource "azurerm_storage_blob" "main" {
+  for_each               = toset(var.files)
+  name                   = basename(each.key)
+  storage_account_name   = azurerm_storage_account.main.name
+  storage_container_name = "$web"
+  type                   = "Block"
+  content_type           = "text/html"
+  content_md5            = filemd5(each.key)
+  source                 = each.key
+}

--- a/terraform/modules/static-website/main.tf
+++ b/terraform/modules/static-website/main.tf
@@ -39,3 +39,13 @@ resource "azurerm_storage_blob" "main" {
   content_md5            = filemd5(each.key)
   source                 = each.key
 }
+
+resource "time_sleep" "main" {
+  depends_on = [azurerm_storage_account.main]
+  create_duration = "20s"
+}
+
+data "http" "get-status" {
+  depends_on = [time_sleep.main]
+  url = azurerm_storage_account.main.primary_web_endpoint
+}

--- a/terraform/modules/static-website/outputs.tf
+++ b/terraform/modules/static-website/outputs.tf
@@ -1,0 +1,3 @@
+output "website_url" {
+  value = azurerm_storage_account.main.primary_web_host
+}

--- a/terraform/modules/static-website/outputs.tf
+++ b/terraform/modules/static-website/outputs.tf
@@ -1,3 +1,7 @@
 output "website_url" {
-  value = azurerm_storage_account.main.primary_web_host
+  value = azurerm_storage_account.main.primary_web_endpoint
+}
+
+output "website_status"{
+  value = data.http.get-status.status_code
 }

--- a/terraform/modules/static-website/variables.tf
+++ b/terraform/modules/static-website/variables.tf
@@ -1,0 +1,9 @@
+variable "files" {
+  description = "A list of files to turn into Azure storage objects for a static website."
+  type        = list(string)
+}
+
+variable "name" {
+  description = "Name to use for static website resources"
+  type        = string
+}

--- a/terraform/modules/static-website/versions.tf
+++ b/terraform/modules/static-website/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/modules/static-website/versions.tf
+++ b/terraform/modules/static-website/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    time = {
+      source = "hashicorp/time"
+      version = "~> 0.11"
+    }
   }
 }
 

--- a/terraform/tests/simple-test.tftest.hcl
+++ b/terraform/tests/simple-test.tftest.hcl
@@ -20,4 +20,14 @@ run "test-vnet" {
   }
 }
 
-run "test-webapp" {}
+run "test-webapp" {
+  module { source = "./modules/static-website" }
+  variables {
+    files = ["./website/index.html"]
+    name  = "unittest"
+  }
+  assert {
+    condition     = strcontains(data.http.get-status.status_code, "200")
+    error_message = "Static website did not return a 200 code"
+  }
+}

--- a/terraform/tests/simple-test.tftest.hcl
+++ b/terraform/tests/simple-test.tftest.hcl
@@ -19,3 +19,5 @@ run "test-vnet" {
     error_message = "Vnet is not in correct resource group."
   }
 }
+
+run "test-webapp" {}

--- a/terraform/website/index.html
+++ b/terraform/website/index.html
@@ -1,0 +1,1 @@
+<h1> This is a static website example </h1>


### PR DESCRIPTION
Made some adjustments to test the static website module. I'd like to revisit this and, without doing something silly like passing in a `time_wait` duration variable, have only the unit test itself create and rely on the `http` data source for its tesing.